### PR TITLE
Endpoint POST para Automovil

### DIFF
--- a/HybridDDDArchitecture/Application/ApplicationServices/AutomovilApplicationService.cs
+++ b/HybridDDDArchitecture/Application/ApplicationServices/AutomovilApplicationService.cs
@@ -1,0 +1,28 @@
+﻿using Application.Repositories;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.ApplicationServices
+{
+    public class AutomovilApplicationService : IAutomovilApplicationService
+    {
+        private readonly IAutomovilRepository _automovilRepository;
+
+        public AutomovilApplicationService(IAutomovilRepository automovilRepository)
+        {
+            _automovilRepository = automovilRepository ?? throw new ArgumentNullException(nameof(automovilRepository));
+        }
+
+        public bool AutomovilExist(string numeroChasis)
+        {
+            if (string.IsNullOrWhiteSpace(numeroChasis))
+                throw new ArgumentNullException(nameof(numeroChasis));
+
+            return _automovilRepository.Query()
+                .Any(a => a.NumeroChasis == numeroChasis);
+        }
+    }
+}

--- a/HybridDDDArchitecture/Application/ApplicationServices/IAutomovilApplicationService.cs
+++ b/HybridDDDArchitecture/Application/ApplicationServices/IAutomovilApplicationService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.ApplicationServices
+{
+    public interface IAutomovilApplicationService
+    {
+        bool AutomovilExist(string numeroChasis);
+    }
+}

--- a/HybridDDDArchitecture/Application/DomainEvents/AutomovilCreado.cs
+++ b/HybridDDDArchitecture/Application/DomainEvents/AutomovilCreado.cs
@@ -1,0 +1,20 @@
+﻿using Core.Application;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.DomainEvents
+{
+    internal class AutomovilCreado : DomainEvent
+    {
+        public int Id { get; set; }
+        public string Marca { get; set; }
+        public string Modelo { get; set; }
+        public string Color { get; set; }
+        public string Fabricacion { get; set; }
+        public string NumeroMotor { get; set; }
+        public string NumeroChasis { get; set; }
+    }
+}

--- a/HybridDDDArchitecture/Application/Mappings/Mapping.cs
+++ b/HybridDDDArchitecture/Application/Mappings/Mapping.cs
@@ -15,6 +15,8 @@ namespace Application.Mappings
             CreateMap<DummyEntity, DummyEntityCreated>().ReverseMap();
             CreateMap<DummyEntity, DummyEntityUpdated>().ReverseMap();
             CreateMap<DummyEntity, DummyEntityDto>().ReverseMap();
+
+            CreateMap<Automovil, AutomovilCreado>().ReverseMap();
         }
     }
 }

--- a/HybridDDDArchitecture/Application/Registrations/ApplicationServicesRegistration.cs
+++ b/HybridDDDArchitecture/Application/Registrations/ApplicationServicesRegistration.cs
@@ -25,6 +25,7 @@ namespace Application.Registrations
 
             /* Application Services */
             services.AddScoped<IDummyEntityApplicationService, DummyEntityApplicationService>();
+            services.AddScoped<IAutomovilApplicationService, AutomovilApplicationService>();
 
             return services;
         }

--- a/HybridDDDArchitecture/Application/UseCases/Automovil/Commands/CreateAutomovil/CreateAutomovilCommand.cs
+++ b/HybridDDDArchitecture/Application/UseCases/Automovil/Commands/CreateAutomovil/CreateAutomovilCommand.cs
@@ -1,0 +1,17 @@
+﻿using Core.Application;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.UseCases.Automovil.Commands.CreateAutomovil
+{
+    public class CreateAutomovilCommand : IRequestCommand<string>
+    {
+        public string Marca { get; set; }
+        public string Modelo { get; set; }
+        public string Color { get; set; }
+    }
+
+}

--- a/HybridDDDArchitecture/Application/UseCases/Automovil/Commands/CreateAutomovil/CreateAutomovilHandler.cs
+++ b/HybridDDDArchitecture/Application/UseCases/Automovil/Commands/CreateAutomovil/CreateAutomovilHandler.cs
@@ -1,0 +1,53 @@
+﻿using Application.ApplicationServices;
+using Application.Constants;
+using Application.DomainEvents;
+using Application.Exceptions;
+using Application.Repositories;
+using Core.Application;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.UseCases.Automovil.Commands.CreateAutomovil
+{
+    internal class CreateAutomovilHandler : IRequestCommandHandler<CreateAutomovilCommand, string>
+    {
+        private readonly ICommandQueryBus _domainBus;
+        private readonly IAutomovilRepository _automovilRepository;
+        private readonly IAutomovilApplicationService _automovilApplicationService;
+
+        public CreateAutomovilHandler(
+            ICommandQueryBus domainBus,
+            IAutomovilRepository automovilRepository,
+            IAutomovilApplicationService automovilApplicationService)
+        {
+            _domainBus = domainBus ?? throw new ArgumentNullException(nameof(domainBus));
+            _automovilRepository = automovilRepository ?? throw new ArgumentNullException(nameof(automovilRepository));
+            _automovilApplicationService = automovilApplicationService ?? throw new ArgumentNullException(nameof(automovilApplicationService));
+        }
+
+        public async Task<string> Handle(CreateAutomovilCommand request, CancellationToken cancellationToken)
+        {
+            var entity = new Domain.Entities.Automovil(request.Marca, request.Modelo, request.Color);
+
+            if (!entity.IsValid) throw new InvalidEntityDataException(entity.GetErrors());
+
+            if (_automovilApplicationService.AutomovilExist(entity.NumeroChasis)) throw new EntityDoesExistException();
+
+            try
+            {
+                object createdId = await _automovilRepository.AddAsync(entity);
+
+                await _domainBus.Publish(entity.To<AutomovilCreado>(), cancellationToken);
+
+                return createdId.ToString();
+            }
+            catch (Exception ex)
+            {
+                throw new BussinessException(ApplicationConstants.PROCESS_EXECUTION_EXCEPTION, ex.InnerException);
+            }
+        }
+    }
+}

--- a/HybridDDDArchitecture/Core.Application.Repositories/IRepository.cs
+++ b/HybridDDDArchitecture/Core.Application.Repositories/IRepository.cs
@@ -14,5 +14,6 @@ namespace Core.Application.Repositories
         Task<TEntity> FindOneAsync(params object[] keyValues);
         void Remove(params object[] keyValues);
         void Update(object id, TEntity entity);
+        IQueryable<TEntity> Query();
     }
 }

--- a/HybridDDDArchitecture/Core.Infraestructure.Repositories.MongoDb/BaseRepository.cs
+++ b/HybridDDDArchitecture/Core.Infraestructure.Repositories.MongoDb/BaseRepository.cs
@@ -75,5 +75,10 @@ namespace Core.Infraestructure.Repositories.MongoDb
             FilterDefinition<TEntity> filter = Builders<TEntity>.Filter.Eq("_id", id);
             Collection.ReplaceOne(filter, entity);
         }
+
+        public IQueryable<TEntity> Query()
+        {
+            throw new NotImplementedException("Query() no está implementado para MongoDb.");
+        }
     }
 }

--- a/HybridDDDArchitecture/Core.Infraestructure.Repositories.Sql/BaseRepository.cs
+++ b/HybridDDDArchitecture/Core.Infraestructure.Repositories.Sql/BaseRepository.cs
@@ -82,5 +82,10 @@ namespace Core.Infraestructure.Repositories.Sql
                 Context.SaveChanges();
             }
         }
+
+        public IQueryable<TEntity> Query()
+        {
+            return Context.Set<TEntity>();
+        }
     }
 }

--- a/HybridDDDArchitecture/Template-API/Controllers/AutomovilController.cs
+++ b/HybridDDDArchitecture/Template-API/Controllers/AutomovilController.cs
@@ -1,0 +1,27 @@
+﻿using Application.UseCases.Automovil.Commands.CreateAutomovil;
+using Core.Application;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Controllers
+{
+    [ApiController]
+    public class AutomovilController : BaseController
+    {
+        private readonly ICommandQueryBus _commandQueryBus;
+
+        public AutomovilController(ICommandQueryBus commandQueryBus)
+        {
+            _commandQueryBus = commandQueryBus ?? throw new ArgumentNullException(nameof(commandQueryBus));
+        }
+
+        [HttpPost("api/v1/[controller]")]
+        public async Task<IActionResult> Create(CreateAutomovilCommand command)
+        {
+            if (command is null) return BadRequest();
+
+            var id = await _commandQueryBus.Send(command);
+
+            return Created($"api/v1/[controller]/{id}", new { Id = id });
+        }
+    }
+}


### PR DESCRIPTION
Se implementa el método CreateAutomovil que permite registrar un nuevo vehículo ingresando únicamente marca, modelo y  color.

Se generan automáticamente los campos NumeroMotor, NumeroChasis y Fabricacion.

Se incluye validación con AutomovilValidator, generación coherente de año, y estructura de identificadores inspirada en formato VIN argentino.

Se verificó persistencia en base de datos y respuesta HTTP 201 con ID autoincremental asignado.

Documentado y probado. Listo para replicar!